### PR TITLE
商品詳細ページでのカテゴリー部分の追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.74.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,8 +116,6 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    enum_help (0.0.17)
-      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.74.0)

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -33,7 +33,18 @@
             %th
               カテゴリー
             %td
-              = @product.category.name
+              - if @product.category.parent.parent.nil?
+                .products-children
+                  = link_to @product.category.parent.name, "#"
+                .products-grandchildren
+                  = link_to @product.category.name, "#"
+              - else
+                .products-info
+                  = link_to @product.category.parent.parent.name, "#"
+                .products-children
+                  = link_to @product.category.parent.name, "#"
+                .products-grandchildren
+                  = link_to @product.category.name, "#"
           %tr
             %th
               ブランド


### PR DESCRIPTION
# What
出品の際に登録したカテゴリーを商品詳細ページで閲覧できるようにする。
# Why
商品詳細を見たユーザーが、よりその商品について分かりやすくなるため。
https://gyazo.com/a6a5f6c3332dd77d9e9615e5272338d7
https://gyazo.com/1d1c088b63cb2f7587a1508c11757ad9