### PR TITLE
[WIP]商品詳細表示の修正２

### DIFF
--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -49,6 +49,7 @@
           .destination__detail
             %p= "〒#{@destination.post_code}"
             %p= Prefecture.find(@destination.prefecture_id).name
+            %p= @destination.city
             %p= @destination.address
             %p= @destination.building_name if @destination.building_name.present?
             %p= "#{@destination.family_name} #{@destination.first_name}"


### PR DESCRIPTION
#What
エラーの原因となっていたshow/html.hamlのスペルミスを修正。
また、ビューに住所の市名が表示されるように修正。
#Why
本番環境、ローカル環境でのエラーを解消するため。