### PR TITLE
会員情報入力後に住所登録

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,11 @@ class ApplicationController < ActionController::Base
   def set_parents
     @parents = Category.where(ancestry: nil)
   end
+
+  def after_sign_in_path_for(resource)
+    new_destination_registration_path
+  end
+
   protected
 
     def configure_permitted_parameters

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -31,4 +31,4 @@
         = link_to "マイページ", users_path, class: "header__menu--btn"
       - else
         = link_to "ログイン", new_user_session_path, class: "header__menu--btn", id: "right-btn"
-        = link_to "新規会員登録", new_user_registration_path, class: "header__menu--btn"
+        = link_to "新規会員登録", new_user_path, class: "header__menu--btn"


### PR DESCRIPTION
# What
会員情報入力後に住所登録のページに遷移するように変更しました。
トップページから新規会員登録ボタンを押した際に
メールアドレス・GoogleAPI・FacebookAPIで登録するか
選択するページに遷移するようにコードを修正しました。
# Why
最終課題制作物チェックシートにユーザー登録の際にまとめて登録できるように記載があったため。

会員情報入力後に住所登録のページに遷移
https://gyazo.com/b2a2803a57881bf3311009bec7fc73d3

トップページからの遷移
https://gyazo.com/ce68e2fe33ac24973d6dd3eed22942d2