### PR TITLE
[WIP]パンくずリストの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
  @import 'font-awesome-sprockets';
  @import 'font-awesome';
  @import "products";
+ @import "breadCrumbs.scss";
 .header__title--text {
     width: 100px;
 }

--- a/app/assets/stylesheets/breadCrumbs.scss
+++ b/app/assets/stylesheets/breadCrumbs.scss
@@ -1,0 +1,38 @@
+.breadCrumbs {
+  width: 100%;
+  margin: 6px 0;
+}
+
+.breadCrumbs ul {
+  padding: 0 0;
+  margin: 0 0;
+  display: table;
+  list-style: none;
+}
+
+.breadCrumbs ul li {
+  margin: 0 10px 0 0;
+  display: table-cell;
+  text-decoration: none;
+}
+
+.breadCrumbs ul li a {
+  color: #3CCACE;
+  font-size: 15px;
+}
+
+.breadCrumbs ul li:first-child::before {
+  content: "\f015";
+  font-family: "Font Awesome 5 Free";
+  font-weight: bold;
+  font-size: 15px;
+}
+
+.breadCrumbs ul li::before {
+  padding: 0 8px 0 4px;
+  content: "\f105";
+  font-family: "Font Awesome 5 Free";
+  font-weight: bold;
+  font-size: 15px;
+  color: #3CCACE;
+  }

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,10 +1,10 @@
 class PurchaseController < ApplicationController
+  before_action :find_product, except: :create
 
   require 'payjp'
 
   def show
     @destination = current_user.destination
-    @product = Product.find(params[:id])
     card = Card.find_by(user_id: current_user.id)
     if @product.buyer_id.present?
       redirect_to controller: :products, action: :show
@@ -79,6 +79,12 @@ class PurchaseController < ApplicationController
         redirect_to action: :card
       end
     end
+  end
+
+  private
+
+  def find_product
+    @product = Product.find(params[:id])
   end
 
 end

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -16,3 +16,10 @@
   #card_token
   #alert{style: "color:red"}
   = f.submit "追加する", id: :token_submit
+
+.breadCrumbs
+  %ul
+    %li= link_to "トップページ", "/"
+    %li= link_to "マイページ", users_path(current_user.id)
+    %li=link_to "支払い方法", cards_path(current_user.id)
+    %li カード登録

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -5,3 +5,9 @@
 = image_tag("/images/#{@card_src}")
 
 = link_to "削除する", card_path, method: :delete
+
+.breadCrumbs
+  %ul
+    %li= link_to "トップページ", "/"
+    %li= link_to "マイページ", users_path(current_user.id)
+    %li 支払い方法

--- a/app/views/products/_breadCrumbs.html.haml
+++ b/app/views/products/_breadCrumbs.html.haml
@@ -1,0 +1,13 @@
+.breadCrumbs
+  %ul
+    %li
+      = link_to "フリマ", "/"
+    - if @product.category.parent.parent.present?
+      %li
+        = link_to @product.category.parent.parent.name, "#"
+    %li
+      = link_to @product.category.parent.name, "#"
+    %li
+      = link_to @product.category.name, "#"
+    %li
+      = @product.name

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -146,3 +146,4 @@
             %button.commentBtn{name: "button", type: "submit"}
               %i.fa.fa-comment
               コメントする
+      = render partial: "breadCrumbs"

--- a/app/views/purchase/_breadCrumbs.html.haml
+++ b/app/views/purchase/_breadCrumbs.html.haml
@@ -1,0 +1,22 @@
+.breadCrumbs
+  %ul
+    %li
+      = link_to "フリマ", "/"
+    - if @product.category.parent.parent.present?
+      %li
+        = link_to @product.category.parent.parent.name, "#"
+    %li
+      = link_to @product.category.parent.name, "#"
+    %li
+      = link_to @product.category.name, "#"
+    %li
+      = link_to @product.name, product_path(@product.id)
+    - if current_page?(action: :show)
+      %li
+        購入内容の確認
+    - else
+      %li
+        = link_to "購入内容の確認", "/products/#{@product.id}/purchase/#{@product.id}"
+    - if current_page?(action: :card)
+      %li
+        カード変更

--- a/app/views/purchase/card.html.haml
+++ b/app/views/purchase/card.html.haml
@@ -16,3 +16,4 @@
   #card_token
   #alert{style: "color:red"}
   = f.submit "追加する", id: :token_submit
+= render partial: "breadCrumbs"

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -57,3 +57,4 @@
         .submit
           = form_tag(action: :pay, method: :post) do
             = submit_tag '購入する', class: :submit__btn
+      = render partial: "breadCrumbs"

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,3 +1,7 @@
 = button_to "メールアドレスで登録する", new_user_registration_path, method: :get
 = button_to 'Googleで登録する', user_google_oauth2_omniauth_authorize_path, method: :post
 = button_to 'Facebookで登録する', user_facebook_omniauth_authorize_path, method: :post
+.breadCrumbs
+  %ul
+    %li= link_to "フリマ", "/"
+    %li 新規会員登録


### PR DESCRIPTION
# What
html,scssファイルを記述し、レイアウトの下部にパンくずリストが表示されるように実装,マークアップまで行った。

# Why
トップページ以外からアクセスした場合であっても、パンクズリストを表示させることによってユーザーは階層構造を素早く理解することができる。それによってより快適にアプリを利用できるようにすることを目的としている。