### PR TITLE
[WIP]購入成功、失敗画面のマークアップ

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -56,9 +56,11 @@ class PurchaseController < ApplicationController
   end
 
   def done
+    render :layout => nil
   end
 
   def fail
+    render :layout => nil
   end
 
   def card

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,1 +1,10 @@
-商品の購入が完了しました
+= stylesheet_link_tag "_top-page", :media => "all"
+= stylesheet_link_tag "_destroy-page", :media => "all"
+= render 'products/header'
+%h2.font-style
+  商品の購入が完了しました
+= link_to "トップページへ戻る", root_path, class: "redirect-btn"
+= link_to new_product_path do
+  .purchaseBtn
+    %span.purchaseBtn__text 出品する
+    %img.purchaseBtn__icon{:src => "/images/material/icon/icon_camera.png"}/

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -7,4 +7,4 @@
 = link_to new_product_path do
   .purchaseBtn
     %span.purchaseBtn__text 出品する
-    %img.purchaseBtn__icon{:src => "/images/material/icon/icon_camera.png"}/
+    = image_tag("/images/material/icon/icon_camera.png", class: "purchaseBtn__icon")

--- a/app/views/purchase/fail.html.haml
+++ b/app/views/purchase/fail.html.haml
@@ -8,4 +8,4 @@
 = link_to new_product_path do
   .purchaseBtn
     %span.purchaseBtn__text 出品する
-    %img.purchaseBtn__icon{:src => "/images/material/icon/icon_camera.png"}/
+    = image_tag("/images/material/icon/icon_camera.png", class: "purchaseBtn__icon")

--- a/app/views/purchase/fail.html.haml
+++ b/app/views/purchase/fail.html.haml
@@ -1,2 +1,11 @@
-申し訳ありません
-この商品はすでに売却されています
+= stylesheet_link_tag "_top-page", :media => "all"
+= stylesheet_link_tag "_destroy-page", :media => "all"
+= render 'products/header'
+%h2.font-style
+  %div 申し訳ありません
+  %div この商品はすでに売却されています
+= link_to "トップページへ戻る", root_path, class: "redirect-btn"
+= link_to new_product_path do
+  .purchaseBtn
+    %span.purchaseBtn__text 出品する
+    %img.purchaseBtn__icon{:src => "/images/material/icon/icon_camera.png"}/


### PR DESCRIPTION
# What
商品購入ボタンをクリック後に遷移する画面のマークアップを、既に実装済みの商品削除後のページと同じレイアウトになるように行った。

# Why
ユーザーに商品が正しく購入できたかどうかの情報を正確に伝えるため。