### PR TITLE
ログイン後の画面遷移を変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    new_destination_registration_path
+    root_path
   end
 
   protected

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -55,9 +55,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    new_destination_registration_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)


### PR DESCRIPTION
# What
ログインのたびに送付先住所登録の画面に遷移していたため、
ユーザー新規登録の際に送付先住所の登録画面に遷移して、
ログイン時はトップページに遷移するようにコードを修正しました。

# Why
ログイン時に毎回送付先住所登録を求められるとユーザーが離れてしまうため

新規登録画面の遷移
https://gyazo.com/197abc18c1d9420f8d07c113e49a6574

ログイン時の画面遷移
https://gyazo.com/dede39fe92a7905cb82874ad97ae70ba