### PR TITLE
login_check_訂正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 class ProductsController < ApplicationController
+  before_action :login_check, only: [:new, :edit, :update, :destroy]
   def index
     @category_parent = Category.where(ancestry: nil)
     @products = Product.all.order(id: "DESC")
@@ -20,7 +21,7 @@ class ProductsController < ApplicationController
 
   def create
     @product = Product.new(product_params)
-    if @product.images.present? && @product.save
+    if @product.images.present? && @product.save 
       redirect_to root_path
     else
       redirect_to  new_product_path
@@ -57,6 +58,13 @@ class ProductsController < ApplicationController
   end
 
   private
+
+  def login_check
+    unless user_signed_in?
+      redirect_to new_user_path
+    end
+  end
+
   def product_params
     params.require(:product).permit(:id, :buyer_id, :name, :category_id, :brand, :status, :cost, :size, :judgment, :prefecture_id, :days, :price, :description, :seller_id, images_attributes: [:image]).merge(seller_id: current_user.id)
   end


### PR DESCRIPTION
WHAT

ログインしたユーザーは、商品出品ページに遷移され、未ログインのユーザーは新規会員登録・ログインページに遷移するように訂正。

WHY

未ログインユーザーが商品出品をしようとした際にエラーページになるため、それを回避するために作成。

ユーザーがログイン時
https://i.gyazo.com/0ea46f8afaae29ff91b40028976a2a37.gif

ユーザーが未ログイン時
https://i.gyazo.com/c0847cdc89c08f1a9816ea9a9965a40c.gif