### PR TITLE
商品詳細画面のビュー崩れを修正

### DIFF
--- a/app/assets/stylesheets/products-show.scss
+++ b/app/assets/stylesheets/products-show.scss
@@ -14,6 +14,7 @@ ul {
 
 li {
   list-style: none;
+  width: 100%;
 }
 
 .itemBox__image--small li {


### PR DESCRIPTION
# What
登録画像が二枚以下の場合、商品画像が左に寄ってしまう問題を修正、中央に来るようにした。

# Why
より美しいレイアウトを実現するため。