### PR TITLE
comment機能とsns認証の修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,10 +18,12 @@ class CommentsController < ApplicationController
 
   def update
     @comment.update(delete_check:1)
+    redirect_back(fallback_location: product_path)
   end
 
   def destroy
     @comment.destroy
+    redirect_back(fallback_location: product_path)
   end
 
   def restore

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
       pass = Devise.friendly_token
       params[:user][:password] = pass
       params[:user][:password_confirmation] = pass
-      super
+      @user = User.new(sign_up_params)
+      unless @user.valid?
+        flash.now[:alert] = @user.errors.full_messages
+        render :new and return
+      end
+      session["devise.regist_data"] = {user: @user.attributes}
+      session["devise.regist_data"][:user]["password"] = params[:user][:password]
+      @destination = @user.build_destination
+      render :destination
     else
       @user = User.new(sign_up_params)
       unless @user.valid?

--- a/app/views/comments/restore.json.jbuilder
+++ b/app/views/comments/restore.json.jbuilder
@@ -1,0 +1,6 @@
+json.comment @comment.comment
+json.id @comment.id
+json.user_nickname @comment.user.nickname
+json.user_id @comment.user.id
+json.created_at @comment.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.product_seller @seller_of_product


### PR DESCRIPTION
# What
コメント機能で削除と完全に削除のリンク先を商品詳細のページに
遷移するようにコードを修正しました。

コメントを一旦削除した後に復元する際の
restore.json.builderを作成しました。

sns認証をウィザード形式に変更しました。

# Why
今までは削除先のページを作成していたが、
ユーザーの使い勝手がよくないこと

restore.json.builderを作成しないと
jsonを用いた実装ができないため

過去のコードだとsns認証の場合は
ユーザー基本情報を入力すれば、
送付先住所を入力しなくても
ログインできるため。

コメント削除→復元
https://gyazo.com/6b1dbf84c2a7994668e1f545c3889382
コメント削除→完全削除
https://gyazo.com/a1ac656acff20526af3463db4f6ee269

SNS認証
https://gyazo.com/e0ee8e0303a27f12887a569fb5e59aea